### PR TITLE
fix: Filtrer les arrêts sans coordonnées pour éviter TypeError

### DIFF
--- a/src/services/Wagon.ts
+++ b/src/services/Wagon.ts
@@ -92,9 +92,11 @@ export class Wagon {
       return this.lineFromDTO(line);
     });
 
-    const stops: SimpleStop[] = json.data.stops.map((stop: any) => {
-      return this.stopFromDTO(stop, lines);
-    });
+    const stops: SimpleStop[] = json.data.stops
+      .filter((stop: any) => stop.averagePosition !== undefined)
+      .map((stop: any) => {
+        return this.stopFromDTO(stop, lines);
+      });
 
     return stops;
   }


### PR DESCRIPTION
Résout l'erreur `Cannot read properties of undefined (reading '0')` qui se produisait lorsque l'API retournait des arrêts sans propriété `averagePosition` (#1)

J'ai ajouté un simple filtre dans la méthode `searchStops` pour exclure les arrêts sans coordonnées 
avant qu'ils ne soient traités par `stopFromDTO`

Alternativement, il aurait été possible de faire plus poussé en rendant `stopFromDTO` nullable dans le type de retour mais ça c'est le quick fix le plus simple en attendant d'investiguer pourquoi certains stops n'ont pas de averagePosition